### PR TITLE
Optimizations

### DIFF
--- a/split-sequence.lisp
+++ b/split-sequence.lisp
@@ -37,6 +37,42 @@
 
 (in-package :split-sequence)
 
+;; declaim it INLINE, and at the end of the file as NOTINLINE, so it can be inlined with local DECLARE's.
+(declaim (inline split-sequence split-sequence-if split-sequence-if-not split-from-start split-from-end))
+
+(defun split-from-start (position-fn sequence start end count remove-empty-subseqs)
+  (let ((length (length sequence)))
+    (loop
+       :for left := start :then (+ right 1)
+       :for right := (min (or (funcall position-fn sequence left) length)
+                          end)
+       :unless (and (= right left)
+                    remove-empty-subseqs) ; empty subseq we don't want
+       :if (and count (>= nr-elts count))
+       ;; We can't take any more. Return now.
+         :return (values subseqs left)
+       :else
+         :collect (subseq sequence left right) :into subseqs
+         :and :sum 1 :into nr-elts
+       :until (>= right end)
+     :finally (return (values subseqs right)))))
+
+(defun split-from-end (position-fn sequence start end count remove-empty-subseqs)
+  (loop
+     :for right := end :then left
+     :for left := (max (or (funcall position-fn sequence right) -1)
+                       (1- start))
+     :unless (and (= right (1+ left))
+                  remove-empty-subseqs) ; empty subseq we don't want
+     :if (and count (>= nr-elts count))
+     ;; We can't take any more. Return now.
+       :return (values (nreverse subseqs) right)
+     :else
+       :collect (subseq sequence (1+ left) right) into subseqs
+       :and :sum 1 :into nr-elts
+     :until (< left start)
+   :finally (return (values (nreverse subseqs) (1+ left)))))
+
 (macrolet ((check-bounds (sequence start end)
              (let ((length (gensym (string '#:length))))
                `(let ((,length (length ,sequence)))
@@ -123,37 +159,6 @@ stopped."
                             (position-if-not predicate sequence :start start :key key))
                           sequence start end count remove-empty-subseqs))))
 
-(defun split-from-end (position-fn sequence start end count remove-empty-subseqs)
-  (loop
-     :for right := end :then left
-     :for left := (max (or (funcall position-fn sequence right) -1)
-                       (1- start))
-     :unless (and (= right (1+ left))
-                  remove-empty-subseqs) ; empty subseq we don't want
-     :if (and count (>= nr-elts count))
-     ;; We can't take any more. Return now.
-       :return (values (nreverse subseqs) right)
-     :else
-       :collect (subseq sequence (1+ left) right) into subseqs
-       :and :sum 1 :into nr-elts
-     :until (< left start)
-   :finally (return (values (nreverse subseqs) (1+ left)))))
-
-(defun split-from-start (position-fn sequence start end count remove-empty-subseqs)
-  (let ((length (length sequence)))
-    (loop
-       :for left := start :then (+ right 1)
-       :for right := (min (or (funcall position-fn sequence left) length)
-                          end)
-       :unless (and (= right left)
-                    remove-empty-subseqs) ; empty subseq we don't want
-       :if (and count (>= nr-elts count))
-       ;; We can't take any more. Return now.
-         :return (values subseqs left)
-       :else
-         :collect (subseq sequence left right) :into subseqs
-         :and :sum 1 :into nr-elts
-       :until (>= right end)
-     :finally (return (values subseqs right)))))
+(declaim (notinline split-sequence split-sequence-if split-sequence-if-not))
 
 (pushnew :split-sequence *features*)

--- a/split-sequence.lisp
+++ b/split-sequence.lisp
@@ -37,6 +37,16 @@
 
 (in-package :split-sequence)
 
+(deftype array-index (&optional (length array-dimension-limit))
+  `(integer 0 (,length)))
+
+(declaim (ftype (function (&rest t) (values list integer))
+                split-sequence)
+         (ftype (function (&rest t) (values list integer))
+                split-sequence-if)
+         (ftype (function (&rest t) (values list integer))
+                split-sequence-if-not))
+
 ;; declaim it INLINE, and at the end of the file as NOTINLINE, so it can be inlined with local DECLARE's.
 (declaim (inline split-sequence split-sequence-if split-sequence-if-not split-from-start split-from-end))
 
@@ -96,6 +106,10 @@ this function; :from-end values of NIL and T are equivalent unless
 :count is supplied. The second return value is an index suitable as an
 argument to CL:SUBSEQ into the sequence indicating where processing
 stopped."
+    (declare (optimize speed)
+             (type array-index start)
+             (type (or null array-index) end count)
+             (type sequence sequence))
     (check-bounds sequence start end)
     (cond
       ((and (not from-end) (null test-not))
@@ -113,7 +127,8 @@ stopped."
       ((and from-end test-not)
        (split-from-end (lambda (sequence end)
                          (position delimiter sequence :end end :from-end t :key key :test-not test-not))
-                       sequence start end count remove-empty-subseqs))))
+                       sequence start end count remove-empty-subseqs))
+      (t (error "it should be impossible to reach this"))))
 
   (defun split-sequence-if (predicate sequence &key (start 0) (end nil) (from-end nil)
                             (count nil) (remove-empty-subseqs nil) (key #'identity))
@@ -128,6 +143,10 @@ this function; :from-end values of NIL and T are equivalent unless
 :count is supplied. The second return value is an index suitable as an
 argument to CL:SUBSEQ into the sequence indicating where processing
 stopped."
+    (declare (optimize speed)
+             (type array-index start)
+             (type (or null array-index) end count)
+             (type sequence sequence))
     (check-bounds sequence start end)
     (if from-end
         (split-from-end (lambda (sequence end)
@@ -150,6 +169,10 @@ of this function; :from-end values of NIL and T are equivalent unless
 :count is supplied. The second return value is an index suitable as an
 argument to CL:SUBSEQ into the sequence indicating where processing
 stopped."
+    (declare (optimize speed)
+             (type array-index start)
+             (type (or null array-index) end count)
+             (type sequence sequence))
     (check-bounds sequence start end)
     (if from-end
         (split-from-end (lambda (sequence end)


### PR DESCRIPTION
without inlining these changes yield only about 3-4% speedup on sbcl, using the following form.

```
(let ((value "cusfFhrjlEafQnkZhRzqSYZccNxuHptrIMPAFMtmbGCNuuyLSnZCwwCkkJZJahHzuBIUomDrMSJOILqzYHowZRqzsnQFzQWhUIoDSjFjjJnBWPhqubKCEtmqKkvKDaVnchqKdFfnzXPfKWozCxQAEBjTfdeQeCwmBLwkZiOZjXHNWtIVwfhIChECIXktdzPcyCosCnGoJwEgdASIoqztsLIxkXwxokLeHbbBgrIdNsOwIUNwczOEQUpUkECVgDbtxXhxDwxUVpEgMhnhkcAcichBrSfUjDnLqbmQxNTRRyrhzNJzjMWMkbgEltNPCHvIotNiwXOZaLSiHejwQlXTPQDpOvtChVbJgQsRYdXJQNLWOGEZSCvPTodrvUglpYAtCkZuriUIkgiRXNsBXkuYegBOpputfJuIujIvnmblnPndQjMwipqrjrOdPaxXhhOodlWBBmnCQATNqYlfooinKtzSupIdaxYuzxrrzyIzYfeEMgRboIDRVaLvmNTDdbTY"))
           (sb-ext:gc)
           (time (loop repeat 300000
                       do (split-sequence:split-sequence #\x value)))
           (values))
```

but when inlining is enabled, then it becomes some 4 times faster with these patches:

```
(funcall (compile
                   nil
                   (lambda ()
                     (declare (inline split-sequence:split-sequence))
                     (let ((value "cusfFhrjlEafQnkZhRzqSYZccNxuHptrIMPAFMtmbGCNuuyLSnZCwwCkkJZJahHzuBIUomDrMSJOILqzYHowZRqzsnQFzQWhUIoDSjFjjJnBWPhqubKCEtmqKkvKDaVnchqKdFfnzXPfKWozCxQAEBjTfdeQeCwmBLwkZiOZjXHNWtIVwfhIChECIXktdzPcyCosCnGoJwEgdASIoqztsLIxkXwxokLeHbbBgrIdNsOwIUNwczOEQUpUkECVgDbtxXhxDwxUVpEgMhnhkcAcichBrSfUjDnLqbmQxNTRRyrhzNJzjMWMkbgEltNPCHvIotNiwXOZaLSiHejwQlXTPQDpOvtChVbJgQsRYdXJQNLWOGEZSCvPTodrvUglpYAtCkZuriUIkgiRXNsBXkuYegBOpputfJuIujIvnmblnPndQjMwipqrjrOdPaxXhhOodlWBBmnCQATNqYlfooinKtzSupIdaxYuzxrrzyIzYfeEMgRboIDRVaLvmNTDdbTY"))
                       (sb-ext:gc)
                       (time (loop repeat 300000
                                   do (split-sequence:split-sequence #\x value)))
                       (values)))))
```

maybe some of that could be gained also by adding some clever type dispatch inside split-sequence ala sb-impl::string-dispatch? a hasty and sloppy check didn't yield anything interesting for me.