### PR TITLE
refer *load-truename* first to avoid implementation specific behavior.

### DIFF
--- a/split-sequence.asd
+++ b/split-sequence.asd
@@ -6,10 +6,7 @@
   :description "Splits a sequence into a list of subsequences
   delimited by objects satisfying a test."
   :license "public domain"
-  :version #.(with-open-file (f (merge-pathnames "version.lisp-expr"
-                                                 (or *compile-file-pathname*
-                                                     *load-truename*)))
-               (read f))
+  :version (:read-file-form "version.lisp-expr")
   :components ((:file "split-sequence"))
   :in-order-to ((asdf:test-op (asdf:load-op :split-sequence-tests)))
   :perform (asdf:test-op :after (op c)

--- a/split-sequence.asd
+++ b/split-sequence.asd
@@ -7,8 +7,8 @@
   delimited by objects satisfying a test."
   :license "public domain"
   :version #.(with-open-file (f (merge-pathnames "version.lisp-expr"
-                                                 (or *compile-file-pathname*
-                                                     *load-truename*)))
+                                                 (or *load-truename*
+                                                     *compile-file-pathname*)))
                (read f))
   :components ((:file "split-sequence"))
   :in-order-to ((asdf:test-op (asdf:load-op :split-sequence-tests)))

--- a/split-sequence.asd
+++ b/split-sequence.asd
@@ -7,8 +7,8 @@
   delimited by objects satisfying a test."
   :license "public domain"
   :version #.(with-open-file (f (merge-pathnames "version.lisp-expr"
-                                                 (or *load-truename*
-                                                     *compile-file-pathname*)))
+                                                 (or *compile-file-pathname*
+                                                     *load-truename*)))
                (read f))
   :components ((:file "split-sequence"))
   :in-order-to ((asdf:test-op (asdf:load-op :split-sequence-tests)))


### PR DESCRIPTION
**Situation**
Loading split-sequence within top level `eval-when` form causes an error on SBCL.

    $ cat foo.lisp
    (eval-when (:compile-toplevel :load-toplevel :execute)
      (asdf:oos 'asdf:load-op :split-sequence))

    * (compile-file "foo.lisp")    ; READ error on SBCL

(Although you may look AVER failed, it is not essential for this time and already reported on SBCL's bug database. Note just an READ error.)

I want to do this to use Common Lisp codes as scripts called from UNIX shell using [roswell](https://github.com/snmsts/roswell).

This problem does not happen on CCL.

**Cause**
The cause seems that the exact value of `*compile-file-pathname*` is implementation dependent. I checked it with the following code.

    $ cat split-sequence.asd
    ...
      :version #.(progn
                   (print *compile-file-pathname*)
                   (print *load-truename*)
                   (with-open-file (f (merge-pathnames "version.lisp-expr"
                                                       (or *compile-file-pathname*
                                                           *load-truename*)))
                     (read f)))
    ...

On SBCL, `*compile-file-pathname*` has full path for the file being compiled. It is merged with "version.lisp-expr" to return /User/mtakagi/Desktop/version.lisp-expr, causing file not found.

    * (compile-file "foo.lisp")
    #P"/Users/mtakagi/Desktop/foo.lisp"
    #P"/Users/mtakagi/Developer/quicklisp/local-projects/split-sequence/split-sequence.asd"
    ...

On CCL, `*compile-file-pathname*` has just name for the file. It is merged with "version.lisp-expr" to return split-sequence/version.lisp-expr, expected path.

    ? (compile-file "foo.lisp")
    #P"foo.lisp"
    #P"/Users/mtakagi/Developer/quicklisp/local-projects/split-sequence/split-sequence.asd"
    ...

**Solution**
Refering `*load-pathname*` first will solve this problem. As far as I tested this change on various cases on SBCL and CCL, it worked well.

    $ cat split-sequence.asd
    ...
      :version #.(with-open-file (f (merge-pathnames "version.lisp-expr"
                                                     (or *load-truename*
                                                         *compile-file-pathname*)))
                     (read f))
    ...

**Failed ideas**
Using `*default-pathname-defaults*` does not work because it does not contain expected path when compile-file split-sequence.asd within `eval-when` form.

    $ cat split-sequence.asd
    ...
      :version #.(progn
                 (print *default-pathname-defaults*)
                 (with-open-file (f (merge-pathnames "version.lisp-expr"
                                                     *default-pathname-defaults*))
                     (read f)))
    ...

    $ cat bar.lisp
    (eval-when (:compile-toplevel :load-toplevel :execute)
      (compile-file "/path/to/split-sequence/split-sequence.asd"))

    * (compile-file "bar.lisp")
    #P"/Users/mtakagi/Desktop/"
    ; error, version.lisp-expr not found

As another, using `asdf:system-source-directory` causes infinite loop.
