### PR TITLE
Add file attributes for Genera

### DIFF
--- a/api.lisp
+++ b/api.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: SPLIT-SEQUENCE -*-
 
 (in-package :split-sequence)
 

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: SPLIT-SEQUENCE -*-
 
 (in-package :split-sequence)
 

--- a/extended-sequence.lisp
+++ b/extended-sequence.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: SPLIT-SEQUENCE -*-
 
 (in-package :split-sequence)
 

--- a/list.lisp
+++ b/list.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: SPLIT-SEQUENCE -*-
 
 (in-package :split-sequence)
 

--- a/package.lisp
+++ b/package.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: CL-USER -*-
 ;;;
 ;;; SPLIT-SEQUENCE
 ;;;

--- a/split-sequence.asd
+++ b/split-sequence.asd
@@ -1,4 +1,4 @@
-;;; -*- Lisp -*-
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; -*-
 
 (defsystem :split-sequence
   :author "Arthur Lemmens <alemmens@xs4all.nl>"

--- a/tests.lisp
+++ b/tests.lisp
@@ -1,7 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
-
-(defpackage :split-sequence/tests
-  (:use :common-lisp :split-sequence :fiveam))
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: SPLIT-SEQUENCE/TESTS -*-
 
 (in-package :split-sequence/tests)
 

--- a/vector.lisp
+++ b/vector.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: SPLIT-SEQUENCE -*-
 
 (in-package :split-sequence)
 

--- a/version.sexp
+++ b/version.sexp
@@ -1,2 +1,2 @@
-;; -*- lisp -*-
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: SPLIT-SEQUENCE -*-
 "2.0.0"


### PR DESCRIPTION
Genera doesn't handle (in-package ...) the way that most people expect, but instead uses the Package file attribute to determine which package to place definitions. This is easily fixed by adding a comment line of the form:
```lisp
;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: CL-USER -*-
```
at the top of the file, with no change to the lisp code required.