### PR TITLE
Enhance testing with coverage

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -32,13 +32,6 @@
 
 (defpackage #:split-sequence
   (:use #:common-lisp)
-  #+:split-sequence-cover
-  (:shadow :inline)
   (:export #:split-sequence
            #:split-sequence-if
            #:split-sequence-if-not))
-
-;;; This reader conditional shadows the symbol inline and
-;;; turns off inlining so test coverage can be better measured.
-#+:split-sequence-cover
-(declaim (declaration split-sequence::inline))

--- a/package.lisp
+++ b/package.lisp
@@ -32,7 +32,7 @@
 
 (defpackage #:split-sequence
   (:use #:common-lisp)
-  #+:split-sequence-no-inline
+  #+:split-sequence-cover
   (:shadow :inline)
   (:export #:split-sequence
            #:split-sequence-if
@@ -40,5 +40,5 @@
 
 ;;; This reader conditional shadows the symbol inline and
 ;;; turns off inlining so test coverage can be better measured.
-#+:split-sequence-no-inline
+#+:split-sequence-cover
 (declaim (declaration split-sequence::inline))

--- a/package.lisp
+++ b/package.lisp
@@ -32,6 +32,13 @@
 
 (defpackage #:split-sequence
   (:use #:common-lisp)
+  #+:split-sequence-cover
+  (:shadow :inline)
   (:export #:split-sequence
            #:split-sequence-if
            #:split-sequence-if-not))
+
+;;; This reader conditional shadows the symbol inline and
+;;; turns off inlining so test coverage can be better measured.
+#+:split-sequence-cover
+(declaim (declaration split-sequence::inline))

--- a/package.lisp
+++ b/package.lisp
@@ -32,7 +32,7 @@
 
 (defpackage #:split-sequence
   (:use #:common-lisp)
-  #+:split-sequence-cover
+  #+:split-sequence-no-inline
   (:shadow :inline)
   (:export #:split-sequence
            #:split-sequence-if
@@ -40,5 +40,5 @@
 
 ;;; This reader conditional shadows the symbol inline and
 ;;; turns off inlining so test coverage can be better measured.
-#+:split-sequence-cover
+#+:split-sequence-no-inline
 (declaim (declaration split-sequence::inline))

--- a/tests.lisp
+++ b/tests.lisp
@@ -195,6 +195,17 @@
   (signals program-error (split-sequence 2 '(1 2 3) :test #'eql :test-not #'eql))
   (signals program-error (split-sequence 2 '(1 2 3) :test nil :test-not nil)))
 
+(test split-sequence.cover
+  ;; Tests for covering branches missed by the other tests
+  (is (equal (multiple-value-list
+              (split-sequence nil '(nil nil 1 nil 2 3)
+                              :count 1 :remove-empty-subseqs t))
+             '(((1)) 4)))
+  (is (equal (multiple-value-list
+              (split-sequence nil '(nil nil 1 nil 2 3)
+                              :count 0 :remove-empty-subseqs t))
+             '(nil 2))))  
+
 ;;; FUZZ TEST
 
 (test split-sequence.fuzz


### PR DESCRIPTION
Tweak split-sequence to enable coverage to be determined under sbcl.   Add a test to cover code that was revealed to be missed by existing tests.